### PR TITLE
Fix RAM overflow from a crafted TZRULES.BIN, plus seven smaller bounds / ISR-safety bugs

### DIFF
--- a/mk4-date/Core/Src/main.c
+++ b/mk4-date/Core/Src/main.c
@@ -607,7 +607,7 @@ static inline void parseByte(uint8_t x){
       dp_pos = text_idx;
       return;
     }
-    if(text_idx > MAX_TEXT_LEN) return;
+    if(text_idx >= MAX_TEXT_LEN) return;  // was '>': at text_idx==MAX_TEXT_LEN this wrote text[32], 1 byte past the buffer
 
     if (text_idx < 10) setDigitPre(text_idx, x);
     text[text_idx++] = x;

--- a/mk4-date/Core/Src/main.c
+++ b/mk4-date/Core/Src/main.c
@@ -488,7 +488,13 @@ static inline void latchDisplay(void){
   buffer_a[3] = pre_buffer_a[3];
   buffer_a[4] = pre_buffer_a[4];
 
+  // dp_pos is the 1-based digit the decimal point attaches to (0 = none). It comes from
+  // text_idx, which the sender can advance past the 10-digit display, and it indexes the
+  // 5-entry buffer_a/buffer_b below. Clamp to each orientation's valid range so a stray or
+  // garbled '.' in the UART stream can't drive a negative / out-of-range index into RAM.
   if (!dp_pos) return;
+  if (inverted) { if (dp_pos > 9) return; }   // inverted: 9-dp_pos goes negative at 10
+  else          { if (dp_pos > 10) return; }  // non-inverted: dp_pos-6 tops out at [4]
 
   if (inverted){
     if (dp_pos>=5) {

--- a/mk4-time/Core/Inc/main.h
+++ b/mk4-time/Core/Inc/main.h
@@ -76,6 +76,7 @@ extern uint16_t buffer_b[];
 
 extern _Bool delayedReadConfigFile;
 extern _Bool delayedCheckOnEject;
+extern volatile uint8_t fatfs_busy;
 
 extern _Bool waitingForLatch;
 extern _Bool resendDate;

--- a/mk4-time/Core/Src/chainloader.c
+++ b/mk4-time/Core/Src/chainloader.c
@@ -360,9 +360,12 @@ void firmwareCheckOnEject(){
   unsigned int rc;
   FIL file1, file2;
 
-  // if QSPI is locked in this context, we have interrupted another fatfs read
-  // we can't wait for it to finish as it's running at lower priority
-  if (QSPI_Locked()) {delayedCheckOnEject=1; return;}
+  // This runs from the USB MSC eject command, i.e. in the USB OTG ISR. FATFS is not
+  // reentrant, so if the lower-priority main loop is mid-operation we must not touch it.
+  // QSPI_Locked() only catches an in-flight QSPI transfer; fatfs_busy covers the whole
+  // main-loop FATFS region, including the gaps between transfers where QSPI_Locked() reads
+  // false. If either says busy, defer back to the main loop (it polls delayedCheckOnEject).
+  if (fatfs_busy || QSPI_Locked()) {delayedCheckOnEject=1; return;}
 
   if (f_open(&file2, "/FWT.BIN", FA_READ) == FR_OK) {
     f_lseek(&file2, TIME_APP_SIZE - 4);

--- a/mk4-time/Core/Src/main.c
+++ b/mk4-time/Core/Src/main.c
@@ -165,6 +165,10 @@ char textDisplay[32];
 _Bool delayedLoadRules = 0;
 _Bool delayedReadConfigFile = 0;
 _Bool delayedCheckOnEject = 0;
+_Bool delayedPostConfigCleanup = 0;
+// Set while the main loop is inside a (non-reentrant) FATFS operation, so the USB-ISR
+// firmware-eject check defers instead of corrupting FATFS state. volatile: ISR-visible.
+volatile uint8_t fatfs_busy = 0;
 uint32_t delayedDisplayFreq = 0;
 
 _Bool waitingForLatch = 0;
@@ -389,6 +393,10 @@ void sendDate( _Bool now ){
   case MODE_TEXT:
     if (textDisplay[0]) {
       i = snprintf((char*)&uart2_tx_buffer[1], 30,"%s", textDisplay);
+      // snprintf returns the length it WOULD have written (newlib-nano follows C99),
+      // not the truncated count; a >29-char TEXT= would otherwise push the ++i below
+      // past uart2_tx_buffer[31]. Clamp to the bytes actually written.
+      if (i > 29) i = 29;
     } else {
       uart2_tx_buffer[1]='-';
       i=1;
@@ -1099,7 +1107,10 @@ void rxConfigString(char c){
     }
     if (k && (v || state>=2)) {
       parseConfigString(key, value);
-      postConfigCleanup();
+      // rxConfigString runs in the USB OTG ISR; postConfigCleanup() calls nextMode()
+      // and sendDate(), which are non-reentrant against the SysTick repaint. Defer it
+      // to the main loop so it runs in thread context, like the file-config path does.
+      delayedPostConfigCleanup=1;
     }
     k=0;
     v=0;
@@ -1136,7 +1147,11 @@ void readConfigFile(void){
   if (f_stat(CONFIG_FILENAME, &fno) == FR_OK) {
     // if unchanged, exit early before touching any config
     // if the file doesn't exist, fall through and fail on the f_open
-    if (fno.fdate==config.fdate && fno.ftime==config.ftime) return;
+    // A zero FAT timestamp (the volume's RTC was unset when config.txt was written)
+    // must not be used as a cache key: config={0} matches it on the very first boot,
+    // so config is never loaded, no mode is enabled, and the first MODE button press
+    // then spins nextMode() forever. Only short-circuit on a real, non-zero stamp.
+    if ((fno.fdate || fno.ftime) && fno.fdate==config.fdate && fno.ftime==config.ftime) return;
     config.fdate=fno.fdate;
     config.ftime=fno.ftime;
   }
@@ -1614,6 +1629,14 @@ uint8_t loadRules( char* cat, char* zo ) {
 
   f_lseek(&file, zoAddr);
 
+  // TZRULES.BIN is host-writable over the USB mass-storage volume, so its length
+  // fields are untrusted: a rowLength larger than one rule slot, or numEntries larger
+  // than the array, would overrun rules[] (global RAM corruption / HardFault). Reject.
+  if (rowLength > sizeof rules[0] || numEntries > MAX_RULES) {
+    f_close(&file);
+    return RULES_HEADER_ERR;
+  }
+
   int i;
   for (i=0;i<numEntries;i++) {
     f_read(&file, &rules[i], rowLength, &rc);
@@ -2079,6 +2102,7 @@ int main(void)
         && latitude>=-90.0 && latitude<=90.0 && longitude>=-180.0 && longitude<=180.0) {
 
       new_position=0;
+      fatfs_busy=1;   // map lookup + loadRulesSingle touch FATFS; block the eject-time check
       FIL mapfile;
       if (f_open(&mapfile, MAP_FILENAME, FA_READ) == FR_OK) {
 #ifdef MEASURE_LOOKUP_TIME
@@ -2108,10 +2132,17 @@ int main(void)
         }
       }
       // else no_map = 1
+      fatfs_busy=0;
     }
 
     if (delayedCheckOnEject) firmwareCheckOnEject();
 
+    if (delayedPostConfigCleanup) {
+      delayedPostConfigCleanup=0;
+      postConfigCleanup();
+    }
+
+    fatfs_busy=1;   // FATFS_remount + readConfigFile + checkDelayedLoadRules touch FATFS
     if (delayedReadConfigFile) {
       FATFS_remount();
       readConfigFile();
@@ -2119,6 +2150,7 @@ int main(void)
     }
 
     checkDelayedLoadRules();
+    fatfs_busy=0;
 
     if (delayedDisplayFreq) setDisplayFreq(delayedDisplayFreq);
 

--- a/mk4-time/USB_DEVICE/App/usbd_cdc_if.c
+++ b/mk4-time/USB_DEVICE/App/usbd_cdc_if.c
@@ -291,6 +291,9 @@ uint8_t CDC_Transmit_FS(uint8_t* Buf, uint16_t Len)
   /* USER CODE BEGIN 7 */
 
   USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassDataCDC;
+  if (hcdc == NULL){          /* not enumerated — same NULL-deref-on-charger-only pattern */
+    return USBD_BUSY;
+  }
   if (hcdc->TxState != 0){
     return USBD_BUSY;
   }
@@ -307,8 +310,17 @@ uint8_t CDC_Copy_Transmit(uint8_t* nmea, uint16_t Len)
   static uint8_t txbuf[NMEA_BUF_SIZE];
 
   USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassDataCDC;
+  /* pClassDataCDC is NULL until a host enumerates the device. On charger-only power it
+     never gets set, so the unconditional hcdc->TxState below dereferenced NULL and
+     hard-faulted on every forwarded NMEA sentence. Bail out cleanly when not enumerated. */
+  if (hcdc == NULL){
+    return USBD_FAIL;
+  }
   if (hcdc->TxState != 0){
     return USBD_BUSY;
+  }
+  if (Len > sizeof txbuf){    /* never overrun the static buffer (defensive) */
+    return USBD_FAIL;
   }
 
   memcpy( txbuf, nmea, Len );


### PR DESCRIPTION
> **Draft / proposal.** Eight self-contained bug fixes found while reading through the Mk IV firmware. All are pre-existing issues in `master`. Two of them — the charger-power hard-fault (#7) and the date-board `CMD_LOAD_TEXT` OOB (#8) — previously sat in my `$PMTXTS` PR (#5); I've consolidated them here so every fix lives in one place. Independent of #6 (astro). The changes are small and localised (5 files; about half the added lines are in-place comments explaining each trigger). They've been flashed in a combined build (with #5/#6) and run without regression — see *Verification*. Left as a **draft** because they touch core paths (timezone load, USB eject, config parse, CDC); happy to split the Critical (#1) into its own PR if you'd rather take that one first.

## The fixes

| # | Severity | Where | |
|---|----------|-------|--|
| 1 | **Critical** | `loadRules()` | RAM overflow from a crafted `TZRULES.BIN` |
| 2 | Major | `firmwareCheckOnEject()` | FATFS re-entered from the USB-eject ISR |
| 3 | Minor | `sendDate()` `MODE_TEXT` | one-byte overrun of `uart2_tx_buffer[32]` (time board) |
| 4 | Major | `latchDisplay()` (date board) | out-of-range `dp_pos` writes outside `buffer_a/b[]` |
| 5 | Minor | `rxConfigString()` | config-over-USB runs `nextMode()`/`sendDate()` in the ISR |
| 6 | Minor | `readConfigFile()` | a zero-timestamp `config.txt` is never loaded → first-boot hang |
| 7 | Major | `CDC_Copy_Transmit()` / `CDC_Transmit_FS()` | NULL deref → hard-fault on charger-only power |
| 8 | Minor | `CMD_LOAD_TEXT` (date board) | one-byte overrun of `text[32]` |

### 1 — `loadRules()` RAM overflow
`TZRULES.BIN` lives on the FAT volume the clock exposes over USB MSC, so its bytes are host-writable. `loadRules()` reads `rowLength` and `numEntries` (each a `uint8_t`) straight from the file, then runs `for (i=0; i<numEntries; i++) f_read(&rules[i], rowLength, …)` into the fixed `rules[MAX_RULES]` (162 × 8 B) with no check. With both bytes maxed at 255 a malformed file writes ~990 bytes past the end of the array into adjacent globals — and it does so at **cold boot and on every zone re-lookup**, so it faults reliably.
**Fix:** reject the file (`RULES_HEADER_ERR`) when `rowLength > sizeof rules[0]` or `numEntries > MAX_RULES`, before the read loop. Valid files are unaffected.
**Repro:** on the mounted MSC volume, set the `rowLength` byte (file offset 4, normally 8) to `0xFF` — or any zone's `numEntries` to `> 162` — then trigger a zone load (power-cycle, or move position so the timezone is re-looked-up).

### 2 — `firmwareCheckOnEject()` FATFS re-entrancy
This runs from the USB MSC eject command, i.e. in the USB OTG ISR, and calls FATFS (`f_open`/`f_read`). It already guards with `if (QSPI_Locked()) { delayedCheckOnEject=1; return; }`, which defers the whole check to the main loop when it sees QSPI contention — so the design isn't naive. The gap is that `QSPI_Locked()` is only true *during* a QSPI transfer; in the lulls between transfers within a single main-loop FATFS call it reads false, the deferral doesn't fire, and the ISR re-enters non-reentrant FATFS anyway (corrupting FATFS state / risking a spurious reset).
**Fix:** a `volatile fatfs_busy` flag set around the main-loop FATFS regions; the guard becomes `if (fatfs_busy || QSPI_Locked())`. It's set/cleared only at the main-loop level, so it stays balanced and can't get stuck and block a legitimate firmware-update-on-eject.

### 3 — `MODE_TEXT` one-byte overrun (time board)
`i = snprintf((char*)&uart2_tx_buffer[1], 30, "%s", textDisplay)` — `snprintf` returns the length it *would* have written, not the truncated count. A 31-char `TEXT=` (the parser caps the value at 31) leaves `i == 31`, so the following `uart2_tx_buffer[++i] = …` writes `[32]`, one past the 32-byte buffer, and the DMA length reads one byte OOB. Self-inflicted via config and only one byte, hence Minor — but easy to close.
**Fix:** `if (i > 29) i = 29;` — clamp to the bytes the `snprintf` actually wrote.

### 4 — date-board `dp_pos` out-of-bounds
`dp_pos` comes from `text_idx`, which the inter-board UART stream can advance past the 10-digit display. `latchDisplay()` then indexes `buffer_a[5]`/`buffer_b[5]` with `9-dp_pos` (goes negative when the display is inverted) and `dp_pos-6` (overruns when it isn't) → OOB writes into adjacent RAM.
**Fix:** bail out at the top of the decimal-point block when `dp_pos` is out of range for the current orientation (`> 9` inverted, `> 10` otherwise), so neither expression can leave `[0,4]`.

### 5 — config-over-USB runs `nextMode()`/`sendDate()` in the ISR
`rxConfigString()` runs in the USB OTG ISR (CDC). On each completed line it called `postConfigCleanup()`, which calls `nextMode()` and `sendDate()`. The priority-0 SysTick repaint preempts the USB ISR and calls `sendDate(0)` directly — so `sendDate()` is genuinely re-entered — and `nextMode()` mutates display state (`displayMode`, the segment buffers) that the repaint reads, so it races too. Result: a torn date row or inconsistent mode state.
**Fix:** defer `postConfigCleanup()` to the main loop via a new `delayedPostConfigCleanup` flag. The file-config path already runs `postConfigCleanup()` in thread context (because `readConfigFile` itself is the thing deferred to the main loop); this gives the USB-CDC path the same thread-context guarantee.

### 6 — zero-timestamp `config.txt` → first-boot hang
`config` is `{0}`-initialised, so the `fdate`/`ftime` mtime-cache key starts at 0. A `config.txt` written while the volume's FAT clock was unset carries a zero timestamp, which *matches* that initial key on the very first boot → `readConfigFile()` returns early → config is never applied → no display mode is enabled → the first MODE-button press spins `nextMode()` forever (there's no watchdog).
**Fix:** never treat a zero stamp as a cache hit — `if ((fno.fdate || fno.ftime) && fno.fdate==config.fdate && fno.ftime==config.ftime) return;`.

### 7 — NMEA-over-CDC NULL deref → hard-fault on charger-only power
`CDC_Copy_Transmit()` and stock `CDC_Transmit_FS()` dereference `hUsbDeviceFS.pClassDataCDC` unconditionally, but it is NULL until a USB host enumerates. With the default `nmea_cdc_level = NMEA_ALL`, every GPS sentence is forwarded to CDC, so on charger-only power — no host — the first forwarded sentence dereferences NULL in ISR context and hard-faults. This is the most common deployment (a dumb USB charger), so it faults reliably there.
**Fix:** a NULL guard at the top of both functions (return cleanly when not enumerated), plus a length clamp before the `memcpy` into the static tx buffer. `mk4-time/USB_DEVICE/App/usbd_cdc_if.c`.

### 8 — date-board `CMD_LOAD_TEXT` one-byte OOB
Distinct from #3 (that's `uart2_tx_buffer` on the time board; this is the `text[]` buffer on the date board). `CMD_LOAD_TEXT` bounds with `if (text_idx > MAX_TEXT_LEN) return;` then writes `text[text_idx++] = x;`. At `text_idx == MAX_TEXT_LEN` (32) the guard passes and it writes `text[32]`, one past the 32-byte array, into the adjacent global. Reachable with a 32-plus-char text-mode string.
**Fix:** `>` → `>=`. `mk4-date/Core/Src/main.c`.

## Verification
- **Flashed and running, no regression** — built into a combined firmware (with #5/#6) and flashed to a real STM32L476 unit; it boots and holds GPS lock with all changes in place. That verifies they don't break normal operation — but I haven't deliberately reproduced each fault's trigger on hardware (e.g. dropping a crafted `TZRULES.BIN`), so the per-bug case above rests on the code, not on a hardware repro of each fault.
- Each fix was re-checked against the surrounding code for off-by-ones and for not regressing the valid case (a normal `TZRULES.BIN`/`config.txt` still loads; `fatfs_busy` is balanced so it can't latch on).
- No new files and no project/linker changes — the build is structurally unchanged.

## Files
- `mk4-time/Core/Src/main.c` — fixes 1, 3, 5, 6, plus the `fatfs_busy` wraps for 2
- `mk4-time/Core/Src/chainloader.c` and `Core/Inc/main.h` — fix 2
- `mk4-time/USB_DEVICE/App/usbd_cdc_if.c` — fix 7
- `mk4-date/Core/Src/main.c` — fixes 4, 8
