### PR TITLE
Sidereal (LST) and apparent-solar time-row modes

### DIFF
--- a/mk4-time/Core/Inc/astro.h
+++ b/mk4-time/Core/Inc/astro.h
@@ -1,0 +1,48 @@
+/*
+ * astro.h — minimal solar/lunar/grid astronomy for the Precision Clock Mk IV.
+ *
+ * Self-contained C99 + <math.h>; NO firmware dependencies, so it compiles and
+ * unit-tests natively (see test_astro.c). All angles in degrees at the API
+ * boundary; UTC instants are passed as a double of Unix seconds.
+ *
+ * Algorithms are low-precision (NOAA/Meeus-class) approximations — accurate to a
+ * fraction of a degree / a minute or two, which is all a 7-segment readout shows,
+ * and cheap enough to evaluate once per mode entry on the STM32's soft-double.
+ */
+#ifndef ASTRO_H
+#define ASTRO_H
+
+/* (a) Sun apparent alt/az for an observer at (lat, lon) decimal degrees, N+/E+,
+ *     at the given UTC instant. Writes azimuth in [0,360) measured from North
+ *     clockwise, and elevation in [-90,90] (negative = below the horizon).
+ *     No refraction or parallax correction. */
+void   sun_az_el(double lat, double lon, double unix_s, double *az, double *el);
+
+/* (b) Sun event times for the UTC calendar day containing unix_s.
+ *     Every output is a decimal UTC hour and MAY be < 0 or > 24 (the event falls
+ *     on the previous/next day) — callers add the local offset and wrap, they do
+ *     NOT clamp. solar_noon is always written. Returns 0 normally; returns
+ *     nonzero on polar day/night (sun never crosses -0.833 deg), in which case
+ *     sunrise/sunset are left untouched and only solar_noon is meaningful.
+ *     Any of the optional twilight pointers may be NULL. */
+int    sun_times(double lat, double lon, double unix_s,
+                 double *sunrise, double *sunset, double *solar_noon,
+                 double *civil_dusk, double *nautical_dusk, double *golden_dusk);
+
+/* (c) Moon. phase is the synodic fraction [0,1): 0=new, .25=first quarter,
+ *     .5=full, .75=last quarter. */
+double moon_phase(double unix_s);
+double moon_illuminated_fraction(double phase);   /* (1 - cos(2*pi*phase)) / 2  */
+int    moon_phase_index(double phase);            /* 0..7, see ASTRO_MOON_NAMES  */
+
+/* (d) Equation of time in minutes (+ = apparent sun ahead of mean/clock sun). */
+double equation_of_time(double unix_s);
+
+/* (e) 6-character Maidenhead locator for (lat, lon). out must hold >= 7 bytes.
+ *     Writes "----\0" if either coordinate is non-finite. */
+void   maidenhead(double lat, double lon, char out[7]);
+
+/* Phase-index -> short name. Index from moon_phase_index(). */
+extern const char *const ASTRO_MOON_NAMES[8];
+
+#endif /* ASTRO_H */

--- a/mk4-time/Core/Inc/astro.h
+++ b/mk4-time/Core/Inc/astro.h
@@ -38,6 +38,9 @@ int    moon_phase_index(double phase);            /* 0..7, see ASTRO_MOON_NAMES 
 /* (d) Equation of time in minutes (+ = apparent sun ahead of mean/clock sun). */
 double equation_of_time(double unix_s);
 
+double local_sidereal_time(double unix_s, double lon); /* LMST, hours [0,24), lon E+ */
+double local_solar_time(double unix_s, double lon);    /* apparent solar, hours [0,24) */
+
 /* (e) 6-character Maidenhead locator for (lat, lon). out must hold >= 7 bytes.
  *     Writes "----\0" if either coordinate is non-finite. */
 void   maidenhead(double lat, double lon, char out[7]);

--- a/mk4-time/Core/Inc/main.h
+++ b/mk4-time/Core/Inc/main.h
@@ -162,6 +162,15 @@ enum {
   MODE_DDMMYYYY,
 #endif
 
+  // Astro pack — GPS-derived astronomy read-outs. SATVIEW-style: the payload
+  // shows on the 10-char date row while the live clock keeps running on the
+  // time row. Enabled individually via the MODE_* config keys, like any mode.
+  MODE_SUN,        // sunrise / sunset / solar noon (local), auto-paged
+  MODE_SUN_AZEL,   // sun azimuth & elevation, now
+  MODE_MOON,       // moon phase index + illuminated %
+  MODE_GRID,       // Maidenhead grid locator
+  MODE_LATLON,     // latitude / longitude, auto-paged
+
   NUM_DISPLAY_MODES
 };
 

--- a/mk4-time/Core/Inc/main.h
+++ b/mk4-time/Core/Inc/main.h
@@ -171,13 +171,20 @@ enum {
   MODE_GRID,       // Maidenhead grid locator
   MODE_LATLON,     // latitude / longitude, auto-paged
 
+  // Alternate-timebase TIME-ROW modes: the big digits tick Local Sidereal Time or
+  // apparent solar time, reseeded from the GPS-disciplined second; the
+  // date row keeps the civil date and a dedicated colon animation marks the mode.
+  MODE_LST,
+  MODE_SOLAR,
+
   NUM_DISPLAY_MODES
 };
 
 enum {
   COUNT_NORMAL =0,
   COUNT_HIDDEN,
-  COUNT_DOWN
+  COUNT_DOWN,
+  COUNT_ALT      // time row driven by the alternate timebase (MODE_LST / MODE_SOLAR)
 };
 
 enum {

--- a/mk4-time/Core/Src/astro.c
+++ b/mk4-time/Core/Src/astro.c
@@ -1,0 +1,140 @@
+/*
+ * astro.c — see astro.h.
+ * Pure C99 + <math.h>; every intermediate is double on purpose (single-precision
+ * loses the sub-arc-minute accuracy these approximations are otherwise good for).
+ */
+#include "astro.h"
+#include <math.h>
+#include <string.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#define J2000_UNIX 946728000.0      /* 2000-01-01 12:00:00 UTC = JD 2451545.0 */
+#define DEG (M_PI / 180.0)
+#define RAD (180.0 / M_PI)
+
+const char *const ASTRO_MOON_NAMES[8] = {
+    "New", "Waxing Crescent", "First Quarter", "Waxing Gibbous",
+    "Full", "Waning Gibbous", "Last Quarter", "Waning Crescent",
+};
+
+static double days_since_j2000(double unix_s) { return (unix_s - J2000_UNIX) / 86400.0; }
+
+/* The shared low-precision solar block: from days-since-J2000 produce mean
+ * longitude L, anomaly g, ecliptic longitude lambda, obliquity eps, and the
+ * apparent right ascension alpha (deg) and declination delta (rad). */
+static void sun_ecliptic(double n, double *L, double *g, double *lambda,
+                         double *eps, double *alpha, double *delta) {
+    double Lv = fmod(280.460 + 0.9856474 * n, 360.0);
+    double gv = fmod(357.528 + 0.9856003 * n, 360.0);
+    double lam = Lv + 1.915 * sin(gv * DEG) + 0.020 * sin(2.0 * gv * DEG);
+    double ep = (23.439 - 0.0000004 * n) * DEG;
+    double al = atan2(cos(ep) * sin(lam * DEG), cos(lam * DEG)) * RAD;
+    double de = asin(sin(ep) * sin(lam * DEG));
+    if (L) *L = Lv;
+    if (g) *g = gv;
+    if (lambda) *lambda = lam;
+    if (eps) *eps = ep;
+    if (alpha) *alpha = al;
+    if (delta) *delta = de;
+}
+
+void sun_az_el(double lat, double lon, double unix_s, double *az, double *el) {
+    double n = days_since_j2000(unix_s);
+    double alpha, delta;
+    sun_ecliptic(n, NULL, NULL, NULL, NULL, &alpha, &delta);
+
+    double gmst = fmod(18.697374558 + 24.06570982441908 * n, 24.0); /* GMST in hours, used as-is */
+    double lst = gmst * 15.0 + lon;                                 /* degrees */
+    double ha = (lst - alpha) * DEG;                                /* radians */
+
+    double e = asin(sin(lat * DEG) * sin(delta) + cos(lat * DEG) * cos(delta) * cos(ha)) * RAD;
+    double a = atan2(-sin(ha), tan(delta) * cos(lat * DEG) - sin(lat * DEG) * cos(ha)) * RAD;
+    if (a < 0.0) a += 360.0;
+    if (el) *el = e;
+    if (az) *az = a;
+}
+
+double equation_of_time(double unix_s) {
+    double n = days_since_j2000(unix_s);
+    double L, alpha;
+    sun_ecliptic(n, &L, NULL, NULL, NULL, &alpha, NULL);
+    double diff = fmod(L - alpha, 360.0);
+    if (diff > 180.0) diff -= 360.0;
+    else if (diff <= -180.0) diff += 360.0;
+    return 4.0 * diff; /* minutes */
+}
+
+int sun_times(double lat, double lon, double unix_s,
+              double *sunrise, double *sunset, double *solar_noon,
+              double *civil_dusk, double *nautical_dusk, double *golden_dusk) {
+    /* Reference instant = 12:00:00 UTC of the calendar day of unix_s. */
+    double noon_unix = trunc(unix_s / 86400.0) * 86400.0 + 43200.0;
+    double n = days_since_j2000(noon_unix);
+    double delta;
+    sun_ecliptic(n, NULL, NULL, NULL, NULL, NULL, &delta);
+    double eot = equation_of_time(noon_unix); /* minutes */
+
+    double noon = 12.0 - eot / 60.0 - lon / 15.0;
+    if (solar_noon) *solar_noon = noon;
+
+    /* Hour angle (deg) at which the sun centre sits at altitude h (deg). */
+    double cosO = (sin(-0.833 * DEG) - sin(lat * DEG) * sin(delta)) / (cos(lat * DEG) * cos(delta));
+    if (cosO < -1.0 || cosO > 1.0) return 1; /* polar day / night: no rise or set */
+    double omega = acos(cosO) * RAD;
+    if (sunrise) *sunrise = noon - omega / 15.0;
+    if (sunset) *sunset = noon + omega / 15.0;
+
+    if (civil_dusk) {
+        double c = (sin(-6.0 * DEG) - sin(lat * DEG) * sin(delta)) / (cos(lat * DEG) * cos(delta));
+        double o = (c < -1.0 || c > 1.0) ? omega : acos(c) * RAD;
+        *civil_dusk = noon + o / 15.0;
+    }
+    if (nautical_dusk) {
+        double c = (sin(-12.0 * DEG) - sin(lat * DEG) * sin(delta)) / (cos(lat * DEG) * cos(delta));
+        double o = (c < -1.0 || c > 1.0) ? omega : acos(c) * RAD;
+        *nautical_dusk = noon + o / 15.0;
+    }
+    if (golden_dusk) {
+        double c = (sin(6.0 * DEG) - sin(lat * DEG) * sin(delta)) / (cos(lat * DEG) * cos(delta));
+        double o = (c < -1.0 || c > 1.0) ? omega : acos(c) * RAD;
+        *golden_dusk = noon + o / 15.0;
+    }
+    return 0;
+}
+
+double moon_phase(double unix_s) {
+    double n = days_since_j2000(unix_s);
+    double phase = fmod((n - 5.26) / 29.53059, 1.0);
+    if (phase < 0.0) phase += 1.0;
+    return phase;
+}
+
+double moon_illuminated_fraction(double phase) { return (1.0 - cos(2.0 * M_PI * phase)) / 2.0; }
+
+int moon_phase_index(double phase) { return ((int)(phase * 8.0 + 0.5)) & 7; }
+
+void maidenhead(double lat, double lon, char out[7]) {
+    if (!isfinite(lat) || !isfinite(lon)) { strcpy(out, "----"); return; }
+    lat = fmin(nextafter(90.0, -INFINITY), fmax(-90.0, lat));
+    lon = fmin(nextafter(180.0, -INFINITY), fmax(-180.0, lon));
+    double LON = lon + 180.0; /* [0,360) */
+    double LAT = lat + 90.0;  /* [0,180) */
+
+    int f0 = (int)(LON / 20.0);            if (f0 < 0) f0 = 0; if (f0 > 17) f0 = 17;
+    int f1 = (int)(LAT / 10.0);            if (f1 < 0) f1 = 0; if (f1 > 17) f1 = 17;
+    int s2 = (int)(fmod(LON, 20.0) / 2.0); if (s2 < 0) s2 = 0; if (s2 > 9) s2 = 9;
+    int s3 = (int)(fmod(LAT, 10.0));       if (s3 < 0) s3 = 0; if (s3 > 9) s3 = 9;
+    int u4 = (int)(fmod(LON, 2.0) * 12.0); if (u4 < 0) u4 = 0; if (u4 > 23) u4 = 23;
+    int u5 = (int)(fmod(LAT, 1.0) * 24.0); if (u5 < 0) u5 = 0; if (u5 > 23) u5 = 23;
+
+    out[0] = (char)('A' + f0);
+    out[1] = (char)('A' + f1);
+    out[2] = (char)('0' + s2);
+    out[3] = (char)('0' + s3);
+    out[4] = (char)('a' + u4);
+    out[5] = (char)('a' + u5);
+    out[6] = '\0';
+}

--- a/mk4-time/Core/Src/astro.c
+++ b/mk4-time/Core/Src/astro.c
@@ -22,6 +22,19 @@ const char *const ASTRO_MOON_NAMES[8] = {
 
 static double days_since_j2000(double unix_s) { return (unix_s - J2000_UNIX) / 86400.0; }
 
+/* Greenwich Mean Sidereal Time in hours [0,24). Factored out so sun_az_el and
+ * local_sidereal_time share one series and can never drift apart. The quadratic
+ * term keeps truncation below ~1 ms for decades (the linear series alone drifts to
+ * ~10 ms by 2033). Note the input is GPS-derived UTC, not UT1: true-sky sidereal
+ * accuracy is floored by DUT1 (up to +/-0.9 s) by design. */
+static double gmst_hours(double n) {
+    double T = n / 36525.0;
+    double g = fmod(18.697374558 + 24.06570982441908 * n + 0.000026 * T * T, 24.0);
+    if (g < 0.0) g += 24.0;
+    if (g >= 24.0) g -= 24.0;
+    return g;
+}
+
 /* The shared low-precision solar block: from days-since-J2000 produce mean
  * longitude L, anomaly g, ecliptic longitude lambda, obliquity eps, and the
  * apparent right ascension alpha (deg) and declination delta (rad). */
@@ -46,7 +59,7 @@ void sun_az_el(double lat, double lon, double unix_s, double *az, double *el) {
     double alpha, delta;
     sun_ecliptic(n, NULL, NULL, NULL, NULL, &alpha, &delta);
 
-    double gmst = fmod(18.697374558 + 24.06570982441908 * n, 24.0); /* GMST in hours, used as-is */
+    double gmst = gmst_hours(n);                                    /* hours */
     double lst = gmst * 15.0 + lon;                                 /* degrees */
     double ha = (lst - alpha) * DEG;                                /* radians */
 
@@ -65,6 +78,27 @@ double equation_of_time(double unix_s) {
     if (diff > 180.0) diff -= 360.0;
     else if (diff <= -180.0) diff += 360.0;
     return 4.0 * diff; /* minutes */
+}
+
+/* Local Mean Sidereal Time, decimal hours [0,24). LMST = GMST + longitude/15
+ * (east-positive). Anchors: GMST(J2000.0) = 18.697374558 h (IAU); Meeus ex. 12.b. */
+double local_sidereal_time(double unix_s, double lon) {
+    double lst = fmod(gmst_hours(days_since_j2000(unix_s)) + lon / 15.0, 24.0);
+    if (lst < 0.0) lst += 24.0;
+    if (lst >= 24.0) lst -= 24.0;   /* fmod residue can round the wrap to exactly 24.0 */
+    return lst; /* hours [0,24) */
+}
+
+/* Local apparent solar ("sundial") time, decimal hours [0,24).
+ * Apparent solar = mean solar (UTC shifted by longitude) + equation of time.
+ * At the sun's meridian transit this equals 12.0 exactly, consistent with
+ * sun_times()'s solar_noon = 12 - eot/60 - lon/15. */
+double local_solar_time(double unix_s, double lon) {
+    double utc_h = fmod(unix_s / 3600.0, 24.0);
+    double t = fmod(utc_h + lon / 15.0 + equation_of_time(unix_s) / 60.0, 24.0);
+    if (t < 0.0) t += 24.0;
+    if (t >= 24.0) t -= 24.0;
+    return t; /* hours [0,24) */
 }
 
 int sun_times(double lat, double lon, double unix_s,

--- a/mk4-time/Core/Src/main.c
+++ b/mk4-time/Core/Src/main.c
@@ -568,15 +568,18 @@ void sendDate( _Bool now ){
     i = sprintf((char*)&uart2_tx_buffer[1], "%s", astro.epoch ? astro.grid : "----");
     break;
   case MODE_LATLON:
+    // RISE/SET-style layout: label, separator space, a sign slot (space when positive), then
+    // the digits — numbers align whether signed or not, and short values keep clear space at
+    // the row's end. A 3-digit longitude can't fit both the separator and the sign slot in
+    // 10 chars, so the separator is dropped just for that case ("LON 179.99" / "LON-179.99").
     if (!astro.have_pos || !astro.epoch) { i = sprintf((char*)&uart2_tx_buffer[1], "LAT  ----"); }
-    else if ((currentTime / 2) % 2 == 0) {             // page latitude / longitude, 2 s each
-      long h = (long)(astro.lat_show * 100.0 + (astro.lat_show < 0 ? -0.5 : 0.5)); // hundredths, rounded
-      if (h < 0) i = sprintf((char*)&uart2_tx_buffer[1], "LAT-%ld.%02ld", -h / 100, -h % 100);
-      else       i = sprintf((char*)&uart2_tx_buffer[1], "LAT %ld.%02ld",  h / 100,  h % 100);
-    } else {
-      long h = (long)(astro.lon_show * 100.0 + (astro.lon_show < 0 ? -0.5 : 0.5));
-      if (h < 0) i = sprintf((char*)&uart2_tx_buffer[1], "LON-%ld.%02ld", -h / 100, -h % 100);
-      else       i = sprintf((char*)&uart2_tx_buffer[1], "LON %ld.%02ld",  h / 100,  h % 100);
+    else {
+      _Bool lat = (currentTime / 2) % 2 == 0;          // page latitude / longitude, 2 s each
+      double v = lat ? astro.lat_show : astro.lon_show;
+      long h = (long)(v * 100.0 + (v < 0 ? -0.5 : 0.5));  // hundredths, rounded
+      long a2 = h < 0 ? -h : h;
+      i = sprintf((char*)&uart2_tx_buffer[1], (a2 >= 10000) ? "%s%c%ld.%02ld" : "%s %c%ld.%02ld",
+                  lat ? "LAT" : "LON", h < 0 ? '-' : ' ', a2 / 100, a2 % 100);
     }
     break;
   }

--- a/mk4-time/Core/Src/main.c
+++ b/mk4-time/Core/Src/main.c
@@ -188,6 +188,13 @@ _Bool resendDate = 0;
 uint32_t LPTIM1_high;
 
 uint8_t displayMode = 0, countMode = 0, colonMode = 0;
+// Civil vs alternate-timebase colon animation: colonMode is the ACTIVE selection that
+// loadColonAnimation() renders; the per-context choices live here and applyColonForMode()
+// swaps between them. The sidereal default must stay visually distinct from civil so
+// MODE_LST/MODE_SOLAR can never masquerade as civil time.
+uint8_t colonModeCivil = 0;
+uint8_t colonModeAlt = COLON_MODE_ALT_SAWTOOTH;
+_Bool colonAltExplicit = 0;    // user explicitly set alt_colon_mode
 uint8_t requestMode = 255;
 uint8_t nmea_cdc_level=0;
 int debug_rtc_val = 0;
@@ -305,6 +312,8 @@ void sendDate( _Bool now ){
 
   switch (displayMode) {
   default:
+  case MODE_LST:       // alt-timebase modes keep the civil date on the date row —
+  case MODE_SOLAR:   // the bottom row stays an unambiguous civil anchor
   case MODE_ISO8601_STD:
     uart2_tx_buffer[1] ='2';
     uart2_tx_buffer[2] ='0';
@@ -660,6 +669,119 @@ void setNextCountdown(time_t nextTime){
 // Store UTC on RTC
 // need to also write zone into backup registers
 // Only called at the start of a second, don't attempt to write subseconds.
+// --- Alternate timebase (MODE_LST / MODE_SOLAR) ------------------------------------------
+// The TIME ROW ticks Local Sidereal Time or apparent solar time. Heavy double
+// math runs in THREAD context once per second (alt_update), staging the reading for the
+// coming civil boundary; the SysTick_Alt_* handlers latch it at the .900 prep mark. The
+// display is quantized to civil second boundaries — value = floor(alt time at the boundary),
+// reseeded every second — so GPS discipline and holdover honesty are inherited from
+// currentTime for free. Sidereal runs 1.00273791x civil: the seconds display double-steps
+// once every ~6 min 5 s. That skip is the authentic signature of a true sidereal clock.
+static volatile struct {
+  uint8_t hh, mm, ss;
+  uint32_t for_time;            // civil epoch this reading is the floor of; 0 = invalid
+} alt_stage;
+static uint8_t alt_hh, alt_mm, alt_ss;   // ISR-owned: what the row currently shows
+static volatile _Bool alt_have_pos = 0;
+static volatile _Bool alt_seed_pending = 0;  // mode entered: thread must seed the row
+static volatile uint8_t alt_gen = 0;         // bumped on mode entry; cancels in-flight staging
+
+// Overlay an alternate HH:MM:SS onto the next7seg staging buffer. The stock
+// setNextTimestamp() has just run (keeping nextBcd / DST / date-row bookkeeping fresh);
+// only the six time-row digit patterns are replaced.
+#define alt_render_next7seg(hh, mm, ss) do { \
+    next7seg.c    = cLut[(ss) % 10]; \
+    next7seg.b[0] = bCat0 | cLut[(hh) / 10] << 2; \
+    next7seg.b[1] = bCat1 | cLut[(hh) % 10] << 2; \
+    next7seg.b[2] = bCat2 | cLut[(mm) / 10] << 2; \
+    next7seg.b[3] = bCat3 | cLut[(mm) % 10] << 2; \
+    next7seg.b[4] = bCat4 | cLut[(ss) / 10] << 2; \
+  } while (0)
+
+// The .900 prep for the alternate modes: stock next-second bookkeeping first, then latch
+// the staged reading — or, if the main loop was starved past the boundary, advance the last
+// shown reading by one second. LST's fallback runs SLOW (2.74 ms/s; the reseed snap is
+// always forward), SOLAR's runs fast by at most ~0.35 ms/s at the EoT extremes — a
+// visible backwards reseed would need ~48+ minutes of continuous main-loop starvation.
+#define alt_prep_next() do { \
+    currentTime++; \
+    setNextTimestamp( currentTime ); \
+    if (alt_stage.for_time == (uint32_t)currentTime) { \
+      alt_hh = alt_stage.hh; alt_mm = alt_stage.mm; alt_ss = alt_stage.ss; \
+    } else if (++alt_ss >= 60) { \
+      alt_ss = 0; \
+      if (++alt_mm >= 60) { alt_mm = 0; if (++alt_hh >= 24) alt_hh = 0; } \
+    } \
+    alt_render_next7seg(alt_hh, alt_mm, alt_ss); \
+    sendDate(0); \
+  } while (0)
+
+// Compute floor-HH:MM:SS of the alternate time at `when` (thread context only: doubles).
+static _Bool alt_compute(uint32_t when, uint8_t *hh, uint8_t *mm, uint8_t *ss){
+  float lat = latitude, lon = longitude;   // one consistent snapshot (astro_update pattern)
+  if (!astro_pos_ok(lat, lon)) return 0;
+  double hours = (displayMode == MODE_LST)
+               ? local_sidereal_time((double)when, (double)lon)
+               : local_solar_time((double)when, (double)lon);
+  if (!(hours >= 0.0) || hours >= 24.0) hours = 0.0;  // NaN / float-residue guard
+  int h2 = (int)hours;
+  double fm = (hours - h2) * 60.0;
+  int m2 = (int)fm;
+  int s2 = (int)((fm - m2) * 60.0);
+  if (h2 > 23) h2 = 23;
+  if (m2 > 59) m2 = 59;
+  if (s2 > 59) s2 = 59;
+  *hh = (uint8_t)h2; *mm = (uint8_t)m2; *ss = (uint8_t)s2;
+  return 1;
+}
+
+// Main-loop staging (thread context — ALL the double math for these modes lives here).
+// Two jobs: (a) SEED after mode entry or position go-live — render + latch the current
+// reading immediately and install the live handlers, so a PPS latch can never show civil
+// digits under the alternate colon; (b) STAGE the reading for the coming civil boundary.
+// A generation counter cancels any in-flight computation when the mode flips mid-pass, so
+// a stale timebase can never be stamped as valid.
+void alt_update(void){
+  if (displayMode != MODE_LST && displayMode != MODE_SOLAR) return;
+
+  uint8_t gen = alt_gen;                 // snapshot: mode flips abort the publish below
+
+  if (alt_seed_pending || !alt_have_pos) {
+    uint8_t hh, mm, ss;
+    if (!alt_compute((uint32_t)currentTime, &hh, &mm, &ss)) {
+      alt_have_pos = 0;                  // stay dashed; retried every pass
+      return;
+    }
+    __disable_irq();
+    if (gen == alt_gen) {
+      alt_hh = hh; alt_mm = mm; alt_ss = ss;
+      alt_render_next7seg(alt_hh, alt_mm, alt_ss);   // alt digits now staged: any latch is honest
+      latchSegments()                                 // and shown immediately (countdown precedent)
+      alt_have_pos = 1;
+      alt_seed_pending = 0;
+    }
+    __enable_irq();
+    if (gen == alt_gen) setPrecision();  // install Alt_Px/PPS now — don't wait for PendSV,
+                                         // or the NoUpdate .900 prep could stage civil digits
+    return;                              // stage the coming boundary on the next pass
+  }
+
+  uint32_t target = (uint32_t)currentTime + 1;
+  if (alt_stage.for_time == target) return;
+  uint8_t hh, mm, ss;
+  if (!alt_compute(target, &hh, &mm, &ss)) {
+    alt_have_pos = 0;                    // position lost: setPrecision dashes it this second
+    alt_stage.for_time = 0;
+    return;
+  }
+  __disable_irq();
+  if (gen == alt_gen) {                  // publish only if no mode flip happened mid-compute
+    alt_stage.hh = hh; alt_stage.mm = mm; alt_stage.ss = ss;
+    alt_stage.for_time = target;         // IRQs masked: fields and stamp are one atomic unit
+  }
+  __enable_irq();
+}
+
 void write_rtc(void){
 
   RTC_DateTypeDef sdatestructure;
@@ -826,6 +948,9 @@ void decodeRMC(void){
       // Under normal conditions, we should only be parsing nmea at around .300 to .400
       // USART1 preemption priority is currently 1, so we could be interrupted by systick here
       setNextTimestamp( currentTime );
+      // In the alternate time-row modes the civil digits just staged must not reach the
+      // display: restore the alt overlay so the boundary latch stays honest.
+      if (countMode == COUNT_ALT) alt_render_next7seg(alt_hh, alt_mm, alt_ss);
       sendDate(0);
     }
   }
@@ -1032,6 +1157,26 @@ float parseBrightness(char *v, _Bool invert){
 #define set_mode_enabled(mode, value) \
   if ((config.modes_enabled[mode] = truthy(value))) requestMode=mode;
 
+static uint8_t parseColonName(const char *value){
+  if (strcasecmp(value, "solid") == 0)        return COLON_MODE_SOLID;
+  if (strcasecmp(value, "heartbeat") == 0)    return COLON_MODE_HEARTBEAT;
+  if (strcasecmp(value, "sawtooth") == 0)     return COLON_MODE_1PPS_SAWTOOTH;
+  if (strcasecmp(value, "alt_sawtooth") == 0) return COLON_MODE_ALT_SAWTOOTH;
+  if (strcasecmp(value, "toggle") == 0)       return COLON_MODE_TOGGLE;
+  return COLON_MODE_SLOWFADE;
+}
+
+// Select the colon animation for the current display mode (idempotent, thread context).
+// Alternate-timebase modes get their own animation so they read as "not civil" at a glance.
+void applyColonForMode(void){
+  uint8_t want = (displayMode == MODE_LST || displayMode == MODE_SOLAR)
+               ? colonModeAlt : colonModeCivil;
+  if (want != colonMode) {
+    colonMode = want;
+    loadColonAnimation();
+  }
+}
+
 void parseConfigString(char *key, char *value) {
 
   if (strcasecmp(key, "text") == 0) {
@@ -1127,6 +1272,10 @@ void parseConfigString(char *key, char *value) {
   } else if (strcasecmp(key, "page_ms") == 0) {
     int v = atoi(value);
     config.page_ms = v < 0 ? 0 : (v > 65535 ? 65535 : v);   // fits uint16; 0 -> default
+  } else if (strcasecmp(key, "MODE_LST") == 0) {
+    set_mode_enabled(MODE_LST, value);
+  } else if (strcasecmp(key, "MODE_SOLAR") == 0) {
+    set_mode_enabled(MODE_SOLAR, value);
   } else if (strcasecmp(key, "Tolerance_time_1ms") == 0) {
     config.tolerance_1ms = atoi(value);
   } else if (strcasecmp(key, "Tolerance_time_10ms") == 0) {
@@ -1139,17 +1288,12 @@ void parseConfigString(char *key, char *value) {
     config.fake_lat = atof(value);
   } else if (strcasecmp(key, "colon_mode") == 0) {
 
-    if (strcasecmp(value, "solid") == 0) {
-      colonMode = COLON_MODE_SOLID;
-    } else if (strcasecmp(value, "heartbeat") == 0) {
-      colonMode = COLON_MODE_HEARTBEAT;
-    } else if (strcasecmp(value, "sawtooth") == 0) {
-      colonMode = COLON_MODE_1PPS_SAWTOOTH;
-    } else if (strcasecmp(value, "alt_sawtooth") == 0) {
-      colonMode = COLON_MODE_ALT_SAWTOOTH;
-    } else if (strcasecmp(value, "toggle") == 0) {
-      colonMode = COLON_MODE_TOGGLE;
-    } else colonMode = COLON_MODE_SLOWFADE;
+    colonModeCivil = parseColonName(value);
+
+  } else if (strcasecmp(key, "alt_colon_mode") == 0) {
+
+    colonModeAlt = parseColonName(value);   // shared by MODE_LST and MODE_SOLAR
+    colonAltExplicit = 1;
 
   } else if (strcasecmp(key, "nmea") == 0) {
 
@@ -1179,7 +1323,13 @@ void parseConfigString(char *key, char *value) {
 }
 
 void postConfigCleanup(void){
-  loadColonAnimation();
+  // Keep the alternate-timebase colon distinct unless the user EXPLICITLY matched them.
+  if (!colonAltExplicit && colonModeAlt == colonModeCivil) {
+    colonModeAlt = (colonModeCivil != COLON_MODE_ALT_SAWTOOTH) ? COLON_MODE_ALT_SAWTOOTH
+                 : COLON_MODE_TOGGLE;
+  }
+  colonMode = 0xFF;             // force applyColonForMode to reload exactly once
+  applyColonForMode();
 
   // check at least one mode is enabled
   uint8_t j = 0;
@@ -1275,7 +1425,9 @@ void readConfigFile(void){
   config.tolerance_100ms = 100000;
   config.zone_override = 0;
   config.brightness_override = -1.0;
-  colonMode = 0;
+  colonModeCivil = 0;
+  colonModeAlt = COLON_MODE_ALT_SAWTOOTH;
+  colonAltExplicit = 0;
 
   FIL file;
 
@@ -1640,6 +1792,59 @@ void SysTick_CountDown_P0(void)
   }
 }
 
+// Alternate-timebase handlers (MODE_LST / MODE_SOLAR): identical to the CountUp family —
+// same cascade, same sub-second painting, same precision ladder — except the .900 prep
+// overlays the staged alternate HH:MM:SS onto next7seg (see alt_prep_next).
+void SysTick_Alt_P3(void)
+{
+  timetick()
+
+  buffer_c[3].low=cLut[millisec];
+  buffer_c[2].low=cLut[centisec];
+  buffer_c[1].low=cLut[decisec];
+
+  HAL_IncTick();
+
+  if (decisec==9 && centisec==0 && millisec==0){
+    alt_prep_next();
+  }
+}
+
+void SysTick_Alt_P2(void) {
+  timetick()
+
+  buffer_c[2].low=cLut[centisec];
+  buffer_c[1].low=cLut[decisec];
+
+  HAL_IncTick();
+
+  if (decisec==9 && centisec==0 && millisec==0){
+    alt_prep_next();
+  }
+}
+
+void SysTick_Alt_P1(void) {
+  timetick()
+
+  buffer_c[1].low=cLut[decisec];
+
+  HAL_IncTick();
+
+  if (decisec==9 && centisec==0 && millisec==0){
+    alt_prep_next();
+  }
+}
+
+void SysTick_Alt_P0(void) {
+  timetick()
+
+  HAL_IncTick();
+
+  if (decisec==9 && centisec==0 && millisec==0){
+    alt_prep_next();
+  }
+}
+
 void SysTick_Dummy(void){
   HAL_IncTick();
 }
@@ -1806,6 +2011,51 @@ void setPrecision(void){
       SetSysTick( &SysTick_CountUp_P0 );
     }
 
+  } else if (countMode == COUNT_ALT) {
+
+    if (!alt_have_pos) {
+      // No usable position (no fix, no fake_longitude): dashes, digits not ticking —
+      // never GMST-as-LST, never a guessed longitude. Re-evaluated every second; the
+      // row goes live the moment a position appears. resendDate keeps the civil date
+      // row refreshing (PendSV's resend check runs right after this) — without it the
+      // date would freeze across midnight while dashed.
+      resendDate = 1;
+      SetPPS( &PPS_NoUpdate );
+      SetSysTick( &SysTick_CountUp_NoUpdate );
+      buffer_b[0] = bCat0 | 0b01000000 << 2;
+      buffer_b[1] = bCat1 | 0b01000000 << 2;
+      buffer_b[2] = bCat2 | 0b01000000 << 2;
+      buffer_b[3] = bCat3 | 0b01000000 << 2;
+      buffer_b[4] = bCat4 | 0b01000000 << 2;
+      buffer_c[0].low = 0b01000000;
+      buffer_c[3].low = 0b01000000;
+      buffer_c[2].low = 0b01000000;
+      buffer_c[1].low = 0b01000000;
+      buffer_c[0].high= 0b11001110;
+    } else if (currentTime - last_pps_time < config.tolerance_1ms){
+      SetPPS( &PPS );
+      buffer_c[0].high= 0b11001110 | cSegDP;
+      SetSysTick( &SysTick_Alt_P3 );
+    } else if (currentTime - last_pps_time < config.tolerance_10ms){
+      SetPPS( &PPS );
+      buffer_c[3].low = 0b01000000;
+      buffer_c[0].high= 0b11001110 | cSegDP;
+      SetSysTick( &SysTick_Alt_P2 );
+    } else if (currentTime - rtc_last_calibration < config.tolerance_100ms){
+      SetPPS( &PPS );
+      buffer_c[3].low = 0b01000000;
+      buffer_c[2].low = 0b01000000;
+      buffer_c[0].high= 0b11001110 | cSegDP;
+      SetSysTick( &SysTick_Alt_P1 );
+    } else {
+      SetPPS( &PPS );
+      buffer_c[3].low = 0b01000000;
+      buffer_c[2].low = 0b01000000;
+      buffer_c[1].low = 0b01000000;
+      buffer_c[0].high= 0b11001110;
+      SetSysTick( &SysTick_Alt_P0 );
+    }
+
   } else if (displayMode == MODE_COUNTDOWN) {
 
     if (config.countdown_to >= currentTime) {
@@ -1881,8 +2131,9 @@ void nextMode(_Bool reverse){
     buffer_c[2].high &= ~cSegDP;
     buffer_c[3].high &= ~cSegDP;
   }
-  if ( displayMode == MODE_ISO_WEEK || justExited(MODE_COUNTDOWN)) {
-    // If we exit countdown mode at .9 seconds
+  if ( displayMode == MODE_ISO_WEEK || justExited(MODE_COUNTDOWN)
+       || justExited(MODE_LST) || justExited(MODE_SOLAR)) {
+    // If we exit countdown/alt mode at .9 seconds
     // it will show the wrong time for .1 seconds
     setNextTimestamp(currentTime);
   }
@@ -1908,6 +2159,22 @@ void nextMode(_Bool reverse){
     TIM2->CCR2 = 0;
     latchSegments();
 
+  } else if (displayMode == MODE_LST || displayMode == MODE_SOLAR) {
+
+    countMode = COUNT_ALT;
+    setNextTimestamp(currentTime);   // stock civil bookkeeping (integer path; countdown-arm cost)
+    // NO double math here: nextMode can run in the USART2 button ISR (priority 0, which
+    // blocks SysTick and the PPS EXTI), and the LST/solar computation is ~100 µs of
+    // soft-double. Invalidate and let the main-loop alt_update() seed within one pass
+    // (<100 ms); until then setPrecision shows the dashed state.
+    alt_gen++;                       // cancels any in-flight staging for the previous timebase
+    alt_stage.for_time = 0;
+    alt_have_pos = 0;
+    alt_seed_pending = 1;
+    setPrecision();
+    TIM2->CCR1 = 0;
+    TIM2->CCR2 = 0;
+
   }
   else {
     if (countMode != COUNT_NORMAL) {
@@ -1919,6 +2186,7 @@ void nextMode(_Bool reverse){
       latchSegments();
     }
   }
+  applyColonForMode();   // idempotent: alt colon on entry, civil colon on exit
   sendDate(1);
 }
 void button1pressed(void){
@@ -2269,6 +2537,10 @@ int main(void)
         if (pg != last_pg && decisec != 9) { last_pg = pg; sendDate(1); }
       }
     }
+
+    // MODE_LST / MODE_SOLAR: stage the next civil boundary's alternate reading
+    // (thread-context doubles; no-op in every other mode)
+    alt_update();
 
 
     /* USER CODE END WHILE */

--- a/mk4-time/Core/Src/main.c
+++ b/mk4-time/Core/Src/main.c
@@ -32,6 +32,7 @@
 #include "qspi_drv.h"
 #include "zonedetect.h"
 #include "chainloader.h"
+#include "astro.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -148,6 +149,20 @@ uint8_t decisec=0, centisec=0, millisec=0;
 
 float longitude=-9999, latitude=-9999;
 _Bool data_valid=0, had_pps=0, rtc_good=0, new_position=1;
+
+// Astro pack — sun/moon/grid read-outs, computed once a second in the main loop
+// (astro_update) and formatted by the sendDate cases, the same compute-in-loop /
+// format-in-ISR split MODE_VBAT uses for vbat.
+struct astro_cache_s {
+  uint32_t epoch;          // currentTime this was computed for; 0 = never computed
+  _Bool    have_pos;       // a usable lat/lon was available
+  _Bool    sun_up_today;   // false = polar day/night (no rise/set this date)
+  int16_t  rise_min, set_min, noon_min;  // local minutes-of-day [0,1440)
+  int16_t  az, el;         // sun azimuth 0..359 / elevation, whole degrees
+  uint8_t  moon_idx, moon_pct;           // phase index 0..7 / illuminated %
+  char     grid[8];        // Maidenhead locator, or "----"
+  float    lat_show, lon_show;           // the snapshot lat/lon, for MODE_LATLON
+} astro = {0};
 #define rtc_last_write RTC->BKP30R
 #define rtc_last_calibration RTC->BKP31R
 uint32_t last_pps_time = 0;
@@ -216,6 +231,57 @@ void memcpyword(volatile uint32_t *dest, volatile uint32_t *src, size_t n){
 }
 
 // 12 bytes at 115200 8E1 is 1.14ms, 32 bytes would be 3.06ms
+// --- Astro pack helpers ----------------------------------------------------
+// A usable position is held in latitude/longitude from either a GPS fix or the
+// configured fake_latitude/fake_longitude; both sit at the -9999 sentinel until
+// a position is known, so a simple range check is the "have we got a fix" test.
+static _Bool astro_pos_ok(float lat, float lon){
+  return lat >= -90.0f && lat <= 90.0f && lon >= -180.0f && lon <= 180.0f;
+}
+// Decimal UTC hour (sun_times may return <0 or >24) -> local minutes-of-day [0,1440).
+static int astro_local_minutes(double utc_h){
+  double h = fmod(utc_h + currentOffset / 3600.0, 24.0);
+  if (h < 0) h += 24.0;
+  int m = (int)(h * 60.0 + 0.5);
+  if (m >= 1440) m -= 1440;
+  return m;
+}
+// Recompute the astro cache (called from the main loop, never the ISR). The
+// double soft-float maths runs here, then the small result struct is swapped in
+// under a brief IRQ mask so sendDate() always reads a consistent snapshot.
+static void astro_update(void){
+  if (astro.epoch == (uint32_t)currentTime) return;     // at most once a second
+  struct astro_cache_s c = {0};
+  c.epoch = (uint32_t)currentTime;
+  double ph = moon_phase((double)currentTime);          // moon needs no fix
+  c.moon_idx = moon_phase_index(ph);
+  c.moon_pct = (uint8_t)(moon_illuminated_fraction(ph) * 100.0 + 0.5);
+  float lat = latitude, lon = longitude;                // one consistent snapshot of the fix
+  c.have_pos = astro_pos_ok(lat, lon);
+  if (c.have_pos) {
+    c.lat_show = lat;
+    c.lon_show = lon;
+    double az, el, rise = 0, set = 0, noon = 0;
+    sun_az_el(lat, lon, (double)currentTime, &az, &el);
+    int ia = (int)(az + 0.5); if (ia >= 360) ia -= 360;
+    c.az = (int16_t)ia;
+    c.el = (int16_t)(el < 0 ? el - 0.5 : el + 0.5);
+    c.sun_up_today = (sun_times(lat, lon, (double)currentTime,
+                                &rise, &set, &noon, 0, 0, 0) == 0);
+    c.noon_min = (int16_t)astro_local_minutes(noon);     // noon is valid even at the poles
+    if (c.sun_up_today) {
+      c.rise_min = (int16_t)astro_local_minutes(rise);
+      c.set_min  = (int16_t)astro_local_minutes(set);
+    }
+    maidenhead(lat, lon, c.grid);
+  } else {
+    strcpy(c.grid, "----");
+  }
+  __disable_irq();
+  astro = c;
+  __enable_irq();
+}
+
 void sendDate( _Bool now ){
   if (waitingForLatch) {
     if (countMode==COUNT_HIDDEN) {
@@ -471,6 +537,47 @@ void sendDate( _Bool now ){
     break;
   case MODE_FIRMWARE_CRC_D:
     uart2_tx_buffer[0]=CMD_SHOW_CRC;
+    break;
+
+  // --- Astro pack: format the main-loop-computed cache onto the date row only,
+  //     leaving the time row as the running clock (SATVIEW-style). --------------
+  case MODE_SUN: {
+    if (!astro.have_pos || !astro.epoch) { i = sprintf((char*)&uart2_tx_buffer[1], "RISE  ----"); break; }
+    int page = (currentTime / 2) % 3;                  // rise -> set -> solar noon, 2 s each
+    // labels padded to 4 chars in the literal ("SET "/"SOL ") so the time digits
+    // line up under RISE without relying on the nano printf honouring "%-4s"
+    const char *lbl = page == 0 ? "RISE" : page == 1 ? "SET " : "SOL ";
+    int m           = page == 0 ? astro.rise_min : page == 1 ? astro.set_min : astro.noon_min;
+    if (!astro.sun_up_today && page != 2) {            // sun never rises/sets today
+      i = sprintf((char*)&uart2_tx_buffer[1], "%s ----", lbl);
+    } else {
+      i = sprintf((char*)&uart2_tx_buffer[1], "%s %02d.%02d", lbl, m / 60, m % 60);
+    }
+    break;
+  }
+  case MODE_SUN_AZEL:
+    if (!astro.have_pos || !astro.epoch) { i = sprintf((char*)&uart2_tx_buffer[1], "AZ -- EL--"); }
+    else if (astro.el < 0) i = sprintf((char*)&uart2_tx_buffer[1], "AZ%03dEL-%02d", astro.az, -astro.el);
+    else                   i = sprintf((char*)&uart2_tx_buffer[1], "AZ%03dEL%02d",  astro.az,  astro.el);
+    break;
+  case MODE_MOON:                                      // UTC only; no fix needed
+    if (!astro.epoch) i = sprintf((char*)&uart2_tx_buffer[1], "MOON -");
+    else              i = sprintf((char*)&uart2_tx_buffer[1], "MOON %d %3d", astro.moon_idx, astro.moon_pct);
+    break;
+  case MODE_GRID:
+    i = sprintf((char*)&uart2_tx_buffer[1], "%s", astro.epoch ? astro.grid : "----");
+    break;
+  case MODE_LATLON:
+    if (!astro.have_pos || !astro.epoch) { i = sprintf((char*)&uart2_tx_buffer[1], "LAT  ----"); }
+    else if ((currentTime / 2) % 2 == 0) {             // page latitude / longitude, 2 s each
+      long h = (long)(astro.lat_show * 100.0 + (astro.lat_show < 0 ? -0.5 : 0.5)); // hundredths, rounded
+      if (h < 0) i = sprintf((char*)&uart2_tx_buffer[1], "LAT-%ld.%02ld", -h / 100, -h % 100);
+      else       i = sprintf((char*)&uart2_tx_buffer[1], "LAT %ld.%02ld",  h / 100,  h % 100);
+    } else {
+      long h = (long)(astro.lon_show * 100.0 + (astro.lon_show < 0 ? -0.5 : 0.5));
+      if (h < 0) i = sprintf((char*)&uart2_tx_buffer[1], "LON-%ld.%02ld", -h / 100, -h % 100);
+      else       i = sprintf((char*)&uart2_tx_buffer[1], "LON %ld.%02ld",  h / 100,  h % 100);
+    }
     break;
   }
   if (now) {
@@ -999,6 +1106,16 @@ void parseConfigString(char *key, char *value) {
   } else if (strcasecmp(key, "MODE_FIRMWARE_CRC") == 0) {
     set_mode_enabled(MODE_FIRMWARE_CRC_D, value);
     set_mode_enabled(MODE_FIRMWARE_CRC_T, value);
+  } else if (strcasecmp(key, "MODE_SUN") == 0) {
+    set_mode_enabled(MODE_SUN, value);
+  } else if (strcasecmp(key, "MODE_SUN_AZEL") == 0) {
+    set_mode_enabled(MODE_SUN_AZEL, value);
+  } else if (strcasecmp(key, "MODE_MOON") == 0) {
+    set_mode_enabled(MODE_MOON, value);
+  } else if (strcasecmp(key, "MODE_GRID") == 0) {
+    set_mode_enabled(MODE_GRID, value);
+  } else if (strcasecmp(key, "MODE_LATLON") == 0) {
+    set_mode_enabled(MODE_LATLON, value);
   } else if (strcasecmp(key, "Tolerance_time_1ms") == 0) {
     config.tolerance_1ms = atoi(value);
   } else if (strcasecmp(key, "Tolerance_time_10ms") == 0) {
@@ -2126,6 +2243,10 @@ int main(void)
 
     if (displayMode == MODE_VBAT)
       measure_vbat();
+
+    if (displayMode == MODE_SUN  || displayMode == MODE_SUN_AZEL || displayMode == MODE_MOON
+        || displayMode == MODE_GRID || displayMode == MODE_LATLON)
+      astro_update();
 
 
     /* USER CODE END WHILE */

--- a/mk4-time/Core/Src/main.c
+++ b/mk4-time/Core/Src/main.c
@@ -207,6 +207,7 @@ struct {
   time_t countdown_to;
   float brightness_override;
   volatile _Bool zone_override;
+  uint16_t page_ms;             // paged modes (SUN/LATLON): sub-screen dwell, ms
   _Bool modes_enabled[NUM_DISPLAY_MODES];
 
 } config = {0};
@@ -238,6 +239,10 @@ void memcpyword(volatile uint32_t *dest, volatile uint32_t *src, size_t n){
 static _Bool astro_pos_ok(float lat, float lon){
   return lat >= -90.0f && lat <= 90.0f && lon >= -180.0f && lon <= 180.0f;
 }
+// Sub-screen dwell (ms) for the paged modes (SUN, LATLON). Unset -> 5500 ms, a
+// subjectively-tuned cadence found by feel. Floored at 250 ms so a tiny value can't
+// flood the date-board UART.
+static uint32_t page_ms(void){ uint32_t m = config.page_ms; return m == 0 ? 5500 : (m < 250 ? 250 : m); }
 // Decimal UTC hour (sun_times may return <0 or >24) -> local minutes-of-day [0,1440).
 static int astro_local_minutes(double utc_h){
   double h = fmod(utc_h + currentOffset / 3600.0, 24.0);
@@ -543,7 +548,7 @@ void sendDate( _Bool now ){
   //     leaving the time row as the running clock (SATVIEW-style). --------------
   case MODE_SUN: {
     if (!astro.have_pos || !astro.epoch) { i = sprintf((char*)&uart2_tx_buffer[1], "RISE  ----"); break; }
-    int page = (currentTime / 2) % 3;                  // rise -> set -> solar noon, 2 s each
+    int page = (uwTick / page_ms()) % 3;               // rise -> set -> solar noon, page_ms each
     // labels padded to 4 chars in the literal ("SET "/"SOL ") so the time digits
     // line up under RISE without relying on the nano printf honouring "%-4s"
     const char *lbl = page == 0 ? "RISE" : page == 1 ? "SET " : "SOL ";
@@ -574,7 +579,7 @@ void sendDate( _Bool now ){
     // 10 chars, so the separator is dropped just for that case ("LON 179.99" / "LON-179.99").
     if (!astro.have_pos || !astro.epoch) { i = sprintf((char*)&uart2_tx_buffer[1], "LAT  ----"); }
     else {
-      _Bool lat = (currentTime / 2) % 2 == 0;          // page latitude / longitude, 2 s each
+      _Bool lat = (uwTick / page_ms()) % 2 == 0;       // page latitude / longitude, page_ms each
       double v = lat ? astro.lat_show : astro.lon_show;
       long h = (long)(v * 100.0 + (v < 0 ? -0.5 : 0.5));  // hundredths, rounded
       long a2 = h < 0 ? -h : h;
@@ -1119,6 +1124,9 @@ void parseConfigString(char *key, char *value) {
     set_mode_enabled(MODE_GRID, value);
   } else if (strcasecmp(key, "MODE_LATLON") == 0) {
     set_mode_enabled(MODE_LATLON, value);
+  } else if (strcasecmp(key, "page_ms") == 0) {
+    int v = atoi(value);
+    config.page_ms = v < 0 ? 0 : (v > 65535 ? 65535 : v);   // fits uint16; 0 -> default
   } else if (strcasecmp(key, "Tolerance_time_1ms") == 0) {
     config.tolerance_1ms = atoi(value);
   } else if (strcasecmp(key, "Tolerance_time_10ms") == 0) {
@@ -2248,8 +2256,19 @@ int main(void)
       measure_vbat();
 
     if (displayMode == MODE_SUN  || displayMode == MODE_SUN_AZEL || displayMode == MODE_MOON
-        || displayMode == MODE_GRID || displayMode == MODE_LATLON)
+        || displayMode == MODE_GRID || displayMode == MODE_LATLON) {
       astro_update();
+      // honour the ms page dwell: the date row otherwise only repaints at 1 Hz, so repaint
+      // the moment a paged mode flips sub-screen. Only with a fix (no-fix shows a
+      // page-independent "----"), and never in the last decisecond -- there the SysTick ISR
+      // runs its own (non-reentrant, shared-UART) sendDate(0), so we'd race it. Same
+      // decisec!=9 guard the existing main-loop sendDate(1) calls use.
+      if ((displayMode == MODE_SUN || displayMode == MODE_LATLON) && astro.have_pos && astro.epoch) {
+        static uint32_t last_pg = 0;
+        uint32_t pg = uwTick / page_ms();
+        if (pg != last_pg && decisec != 9) { last_pg = pg; sendDate(1); }
+      }
+    }
 
 
     /* USER CODE END WHILE */

--- a/mk4-time/test/test_astro.c
+++ b/mk4-time/test/test_astro.c
@@ -1,0 +1,104 @@
+/* Native unit test for ../Core/Src/astro.c against the reference vectors used to
+ * develop the astro pack. Not part of the firmware build (test/ is not a project
+ * source path); build & run on a host:
+ *
+ *   cc -std=c99 -O2 -I ../Core/Inc ../Core/Src/astro.c test_astro.c -lm -o test_astro && ./test_astro
+ */
+#include "astro.h"
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+static int fails = 0, total = 0;
+
+static void chk(const char *name, double got, double exp, double tol) {
+    total++;
+    double d = fabs(got - exp);
+    if (d > tol || !isfinite(got)) {
+        printf("  FAIL %-28s got %.6f  exp %.6f  (|d|=%.6f > %.6f)\n", name, got, exp, d, tol);
+        fails++;
+    } else {
+        printf("  ok   %-28s %.6f  (|d|=%.2e)\n", name, got, d);
+    }
+}
+
+static void chks(const char *name, const char *got, const char *exp) {
+    total++;
+    if (strcmp(got, exp) != 0) { printf("  FAIL %-28s got \"%s\"  exp \"%s\"\n", name, got, exp); fails++; }
+    else                        printf("  ok   %-28s \"%s\"\n", name, got);
+}
+
+struct loc { const char *tag; double lat, lon, t; };
+
+int main(void) {
+    struct loc V1 = {"Greenwich", 51.4779, -0.0015, 1718971200}; /* 2024-06-21 12:00 */
+    struct loc V2 = {"Sydney", -33.8568, 151.2153, 1704067200};  /* 2024-01-01 00:00 */
+    struct loc V3 = {"Quito", -0.1807, -78.4678, 1411819200};    /* 2014-09-27 12:00 */
+    struct loc V4 = {"Fairbanks", 64.8378, -147.7164, 1671460200}; /* 2022-12-19 14:30 */
+    struct loc *V[4] = {&V1, &V2, &V3, &V4};
+
+    double az, el;
+    printf("sun_az_el:\n");
+    double exp_el[4] = {61.9537, 61.9872, 13.7817, -29.3334};
+    double exp_az[4] = {179.0572, 75.1095, 91.7169, 82.8687};
+    for (int i = 0; i < 4; i++) {
+        char nm[40];
+        sun_az_el(V[i]->lat, V[i]->lon, V[i]->t, &az, &el);
+        sprintf(nm, "el %s", V[i]->tag); chk(nm, el, exp_el[i], 0.001);
+        sprintf(nm, "az %s", V[i]->tag); chk(nm, az, exp_az[i], 0.001);
+    }
+
+    printf("equation_of_time (min):\n");
+    double exp_eot[4] = {-1.92784, -3.09298, 8.99946, 2.88245};
+    for (int i = 0; i < 4; i++) {
+        char nm[40]; sprintf(nm, "eot %s", V[i]->tag);
+        chk(nm, equation_of_time(V[i]->t), exp_eot[i], 0.0005);
+    }
+
+    printf("moon_phase / illuminated:\n");
+    double exp_ph[4] = {0.49108, 0.64968, 0.10744, 0.86985};
+    double exp_il[4] = {0.99921, 0.79471, 0.10966, 0.15807};
+    int exp_idx[4] = {4, 5, 1, 7};
+    for (int i = 0; i < 4; i++) {
+        char nm[40]; double p = moon_phase(V[i]->t);
+        sprintf(nm, "phase %s", V[i]->tag); chk(nm, p, exp_ph[i], 0.0002);
+        sprintf(nm, "illum %s", V[i]->tag); chk(nm, moon_illuminated_fraction(p), exp_il[i], 0.0005);
+        sprintf(nm, "idx %s", V[i]->tag); chk(nm, moon_phase_index(p), exp_idx[i], 0.0);
+    }
+
+    printf("sun_times (UTC h):\n");
+    double rise, set, noon, civ, nau, gold;
+    /* V1 Greenwich */
+    sun_times(V1.lat, V1.lon, V1.t, &rise, &set, &noon, &civ, &nau, &gold);
+    chk("noon V1", noon, 12.032231, 0.0003);
+    chk("rise V1", rise, 3.715903, 0.0003);
+    chk("set  V1", set, 20.348558, 0.0003);
+    chk("civil V1", civ, 21.143501, 0.0003);
+    chk("naut V1", nau, 22.383822, 0.0003);
+    /* V3 Quito */
+    sun_times(V3.lat, V3.lon, V3.t, &rise, &set, &noon, NULL, NULL, NULL);
+    chk("noon V3", noon, 17.081196, 0.0003);
+    chk("rise V3", rise, 11.025277, 0.0003);
+    chk("set  V3", set, 23.137114, 0.0003);
+    /* V4 Fairbanks (events spill past midnight) */
+    sun_times(V4.lat, V4.lon, V4.t, &rise, &set, &noon, &civ, &nau, &gold);
+    chk("noon V4", noon, 21.798861, 0.0005);
+    chk("rise V4", rise, 19.944940, 0.0005);
+    chk("set  V4", set, 23.652783, 0.0005);
+    chk("civil V4", civ, 25.076604, 0.0005);
+    chk("naut V4", nau, 26.273118, 0.0005);
+
+    printf("maidenhead:\n");
+    char g[7];
+    maidenhead(V1.lat, V1.lon, g); chks("grid V1", g, "IO91xl");
+    maidenhead(V2.lat, V2.lon, g); chks("grid V2", g, "QF56od");
+    maidenhead(V3.lat, V3.lon, g); chks("grid V3", g, "FI09st");
+    maidenhead(V4.lat, V4.lon, g); chks("grid V4", g, "BP64du");
+    maidenhead(51.508, -0.128, g); chks("Trafalgar Sq", g, "IO91wm");
+    maidenhead(41.714, -72.728, g); chks("ARRL HQ", g, "FN31pr");
+    maidenhead(-41.283, 174.745, g); chks("Wellington", g, "RE78ir");
+    maidenhead(1.0 / 0.0, 0.0, g); chks("non-finite", g, "----");
+
+    printf("\n%d/%d passed, %d failed\n", total - fails, total, fails);
+    return fails ? 1 : 0;
+}

--- a/mk4-time/test/test_astro.c
+++ b/mk4-time/test/test_astro.c
@@ -99,6 +99,25 @@ int main(void) {
     maidenhead(-41.283, 174.745, g); chks("Wellington", g, "RE78ir");
     maidenhead(1.0 / 0.0, 0.0, g); chks("non-finite", g, "----");
 
+    printf("local_sidereal_time (h):\n");
+    /* GMST at J2000.0 = 18.697374558 h (IAU); Meeus ex. 12.b, 1987-04-10 19:21:00 UT
+     * -> mean GMST 8h34m57.1s = 8.582525 h. LST = GMST + lon/15 checks shift + wrap. */
+    chk("LST J2000 lon0",        local_sidereal_time(946728000.0,   0.0), 18.697375, 0.0001);
+    chk("LST Meeus lon0",        local_sidereal_time(545080860.0,   0.0),  8.582525, 0.0001);
+    chk("LST J2000 lon -75",     local_sidereal_time(946728000.0, -75.0), 13.697375, 0.0001);
+    chk("LST J2000 lon +90wrap", local_sidereal_time(946728000.0,  90.0),  0.697375, 0.0001);
+
+    printf("local_solar_time (h):\n");
+    /* At meridian transit apparent solar time is 12:00 exactly. Build that instant from
+     * sun_times()'s solar_noon and confirm -- catches any longitude/EoT sign or wrap error. */
+    for (int i = 0; i < 4; i++) {
+        double nn;
+        sun_times(V[i]->lat, V[i]->lon, V[i]->t, NULL, NULL, &nn, NULL, NULL, NULL);
+        double noon_unix = trunc(V[i]->t / 86400.0) * 86400.0 + nn * 3600.0;
+        char nm[40]; sprintf(nm, "solar@noon %s", V[i]->tag);
+        chk(nm, local_solar_time(noon_unix, V[i]->lon), 12.0, 0.02);
+    }
+
     printf("\n%d/%d passed, %d failed\n", total - fails, total, fails);
     return fails ? 1 : 0;
 }

--- a/qspi/config.txt
+++ b/qspi/config.txt
@@ -100,3 +100,31 @@ mode_satview = 0
 
 # show coin cell voltage
 mode_vbat = 0
+
+
+## astro modes (GPS-derived)
+# These show on the date row while the live clock keeps running on the time row.
+# They use the current position; with no GPS fix they fall back to fake_latitude/
+# fake_longitude below (handy indoors), or show "----" if neither is set.
+
+# Sunrise / sunset / solar noon (local time). Pages every 2 s: RISE -> SET -> SOL.
+MODE_SUN = disabled
+
+# Sun azimuth & elevation right now, e.g. "AZ142EL38" (degrees; elevation may be negative).
+MODE_SUN_AZEL = disabled
+
+# Moon: phase index 0-7 then illuminated %, e.g. "MOON 4 99".
+# Index: 0 new, 1 waxing crescent, 2 first quarter, 3 waxing gibbous,
+#        4 full, 5 waning gibbous, 6 last quarter, 7 waning crescent.
+MODE_MOON = disabled
+
+# Maidenhead grid locator, e.g. "IO91xl".
+MODE_GRID = disabled
+
+# Latitude / longitude in decimal degrees. Pages every 2 s: LAT -> LON.
+MODE_LATLON = disabled
+
+# Fixed position for the astro modes when there is no GPS fix (decimal degrees, N+/E+).
+# Note: setting these also pins the clock's position (GPS position updates are ignored).
+#fake_latitude  = 51.48
+#fake_longitude = -0.01

--- a/qspi/config.txt
+++ b/qspi/config.txt
@@ -107,7 +107,7 @@ mode_vbat = 0
 # They use the current position; with no GPS fix they fall back to fake_latitude/
 # fake_longitude below (handy indoors), or show "----" if neither is set.
 
-# Sunrise / sunset / solar noon (local time). Pages every 2 s: RISE -> SET -> SOL.
+# Sunrise / sunset / solar noon (local time). Pages RISE -> SET -> SOL (see page_ms).
 MODE_SUN = disabled
 
 # Sun azimuth & elevation right now, e.g. "AZ142EL38" (degrees; elevation may be negative).
@@ -121,8 +121,12 @@ MODE_MOON = disabled
 # Maidenhead grid locator, e.g. "IO91xl".
 MODE_GRID = disabled
 
-# Latitude / longitude in decimal degrees. Pages every 2 s: LAT -> LON.
+# Latitude / longitude in decimal degrees. Pages LAT -> LON (see page_ms).
 MODE_LATLON = disabled
+
+# Dwell per sub-screen for the paged modes (MODE_SUN, MODE_LATLON), in milliseconds.
+# Default 5500 (a subjectively-tuned cadence, found by feel); floored at 250.
+page_ms = 5500
 
 # Fixed position for the astro modes when there is no GPS fix (decimal degrees, N+/E+).
 # Note: setting these also pins the clock's position (GPS position updates are ignored).

--- a/qspi/config.txt
+++ b/qspi/config.txt
@@ -127,6 +127,24 @@ MODE_LATLON = disabled
 # Dwell per sub-screen for the paged modes (MODE_SUN, MODE_LATLON), in milliseconds.
 # Default 5500 (a subjectively-tuned cadence, found by feel); floored at 250.
 page_ms = 5500
+||||||| parent of 2f18d8e (Add sidereal (LST) and apparent-solar time-row modes)
+# Local Sidereal Time as a LIVE TICKING CLOCK on the time row (big digits). The date row
+# keeps the civil date, and the colons animate differently (alt_colon_mode below) so it
+# can never be mistaken for civil time. Sidereal runs 1.00273791x faster than civil, so the
+# seconds display double-steps about once every 6 minutes -- real sidereal behaviour, not a
+# glitch. Needs a position (GPS fix or fake_longitude); shows dashes without one.
+MODE_LST = disabled
+
+# Apparent solar time on the time row -- what a sundial reads: UTC shifted by
+# your longitude plus the equation of time. Reads exactly 12:00:00 at local solar noon.
+MODE_SOLAR = disabled
+
+# Colon animation while MODE_LST / MODE_SOLAR is shown, so the alternate timebase is
+# unmistakable at a glance -- solar especially, which can sit within minutes of civil.
+# Same names as colon_mode; automatically kept different from your civil colon unless you
+# explicitly set them equal here. One of: slowfade, heartbeat, sawtooth, alt_sawtooth,
+# toggle, solid
+#alt_colon_mode = alt_sawtooth
 
 # Fixed position for the astro modes when there is no GPS fix (decimal degrees, N+/E+).
 # Note: setting these also pins the clock's position (GPS position updates are ignored).


### PR DESCRIPTION
Draft — two new opt-in **time-row** modes that turn the big HH:MM:SS digits into a live ticking clock in an alternate timebase:

- **`MODE_LST`** — Local Sidereal Time (a GPS-disciplined sidereal clock, for the astronomers).
- **`MODE_SUNDIAL`** — local apparent solar time; reads exactly 12:00:00 at your meridian transit.

### Stacking note (please read first)
This builds on **#6 (astro pack)** — it reuses `astro.c`'s solar routines. Until #6 lands, this PR's diff includes #6's commits too; the **sidereal-specific change is the single top commit, `29acd18`** (that's the one to review). Once #6 merges I'll rebase and this collapses to just that commit. Happy to reorder or split further if you'd prefer.

### How it stays honest and leaves civil timekeeping untouched
It clones the existing `MODE_COUNTDOWN` takeover (new `COUNT_ALT`, four `SysTick_Alt_Px` clones). The GMST/EoT double maths runs **once per second in the main loop**; the SysTick handlers latch pre-rendered digits at the **true PPS boundary** via the untouched `PPS()` path. So civil `currentTime`, PPS discipline, `calibrateRTC`/`write_rtc` and the date row are byte-identical to stock; the `setPrecision` P3→P0 sub-second digit-hiding applies to sidereal unchanged; and no double-precision maths ever runs in an ISR.

The display is quantised to civil second boundaries and reseeded each second, so sidereal's 1.00273791× rate makes the seconds display **double-step about once every 6 minutes** — deliberately visible, the honest signature of a GPS-disciplined sidereal clock rather than a rate-warped one. A dedicated colon animation (`alt_colon_mode`, default `alt_sawtooth`, kept distinct from the civil colon) marks the mode so it can't be mistaken for civil time; with no position the row shows dashes rather than GMST-as-LST.

### Maths
`astro.c` regains `local_sidereal_time()` / `local_solar_time()` with the GMST series factored into one `gmst_hours()` helper (+T² term for sub-ms accuracy for decades). Native suite **53/53**, including the IAU GMST(J2000.0) anchor and Meeus example 12.b. DUT1 (±0.9 s) is the documented accuracy floor.

**Default-off**: without the config keys, no alt handler is installed and behaviour is identical to stock. Builds clean (`-O3`, no new warnings); passed an adversarial review pass. **Hardware validation still pending** — hence draft.
